### PR TITLE
Rework the cost and sustainability sections

### DIFF
--- a/papers/project_jupyter/paper.rst
+++ b/papers/project_jupyter/paper.rst
@@ -127,7 +127,6 @@ is *technically* possible, it is not yet *practically* possible. This paper
 introduces Binder 2.0, a tool that takes us one step closer towards workflows
 that make computational work practical to share.
 
-
 Binder consists of a set of tools for creating sharable, interactive, and
 deterministic environments that run on personal computers and cloud resources.
 It manages the technical complexity around:
@@ -586,8 +585,8 @@ of the technology, as well as digital public infrastructure that can be used to 
 interactive code repositories. This service runs at the URL ``https://mybinder.org``,
 and will be discussed in the final section.
 
-Mybinder.org
-------------
+Mybinder.org: Sustaining the Cost of a public service
+-----------------------------------------------------
 
 You can access a public deployment of BinderHub at ``mybinder.org``.
 This a web service that the Binder and JupyterHub team run both as a
@@ -619,17 +618,18 @@ in Python <https://sphinx-gallery.readthedocs.io/en/latest/advanced_configuratio
 with Sphinx Gallery, and sharing `interactive content <http://greenteapress.com/wp/think-dsp/>`_
 that requires a language-specific kernel in order to run.
 
-Cost and sustainability  for ``mybinder.org``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Cost of ``mybinder.org``
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-Mybinder.org is currently funded through a grant from the Moore foundation, and
-the team is actively exploring new models for keeping the service running sustainably.
-The public service currently restricts the hardware available to users in several
-ways in order to keep costs down. For example, users are only given access to one
-CPU, two gigabytes of RAM, can only access public git repositories, and are
-restricted in the kinds of network I/O that can take place. It currently
-runs on the Google Cloud Platform (though it could run on any setup that runs
-on top of Kubernetes).
+We have designed the public service to be as cost effective as possible.
+``mybinder.org`` restricts users to one CPU, two GB of RAM. We save a great deal
+by not providing users with persistent storage across sessions. Users can only
+access public git repositories, and are restricted in the kinds of network I/O
+that can take place. In addition, a BinderHub deployment efficiently uses its
+resources in order to avoid over-provisioning cloud resources.  Because
+Kubernetes is a open source system for managing containers, while Binder
+currently runs on the Google Cloud Platform, it could run on any setup that runs
+on top of Kubernetes if that setup proved more cost effective.
 
 .. figure:: images/cost_breakdown.png
    :align: center
@@ -640,21 +640,18 @@ on top of Kubernetes).
    resources used) has kept costs relatively flat. As a result, ``mybinder.org``
    currently operates at about 5 cents per user per day.
 
-The decision to avoid the notion of a user "identity" in particular has strong
-effects on the cost of running a BinderHub server. Because users do not require
-persistent storage (e.g. the content of any changes they make to Jupyter
-Notebooks throughout a session), a significant cost of running a JupyterHub
-is avoided. In addition,
-a BinderHub deployment can efficiently use the resources available to it in
-order to avoid over-provisioning cloud resources as much as possible.
+Currently, ``mybinder.org`` costs several hundred dollars per day to host. At
+roughly 50,000 users per week, this comes out to around 
+$\frac{220 \times30}{50000} \approx 13$cents per user. 
+The ``mybinder.org`` team publishes its daily hosting costs in `a public repository on GitHub <https://github.com/binder-examples/binder-billing>`_. 
+We hope that this serves to encourage other organizations to deploy BinderHub 
+for their own purposes, demonstrating how cost-effective it is.
 
-Currently, the hosting bill for ``mybinder.org`` runs at a cost of several hundred dollars per
-day. At roughly 50,000 users per week, this comes out to around $\frac{220 \times30}{50000} \approx 13$cents per
-user. The ``mybinder.org`` team publishes its daily hosting costs in `a public
-repository on GitHub <https://github.com/binder-examples/binder-billing>`_.
-It hopes that this serves to encourage other organizations to deploy BinderHub
-for their own purposes, since it is possible to do so in a cost-effective
-manner.
+Sustainabiliyt of ``mybinder.org``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Mybinder.org is currently funded through a grant from the Moore foundation, and
+the team is actively exploring new models for keeping the service running sustainably.
 
 The Binder team is exploring multiple models
 for sustaining the public digital infrastructure ``mybinder.org``, the team required to operate it, and the


### PR DESCRIPTION
I actually think we need to change all of the ``mybinder.org``'s to be links and not the monospace font… but for now this should be fine. Mostly tried to tighten it up and delineate the purposes of the two parts.